### PR TITLE
Update link for Hexagon

### DIFF
--- a/hextools.json
+++ b/hextools.json
@@ -42,7 +42,7 @@
     {
         "name": "Hexagon",
         "description": "A programming language for Hex Casting. Hexagon is a superset of the hexpattern format, adding variables, if statements, and more.",
-        "link": "https://github.com/Master-Bw3/Hexagon"
+        "link": "https://master-bw3.github.io/Hexagon/"
     },
     {
         "name": "HexDrawAssist",


### PR DESCRIPTION
Hexagon has a website now, so this site should link to that rather than the Github repo.